### PR TITLE
CCSJP-32471 - delete pie as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cambiahealth/platform-infrastructure @cambiahealth/gaea
+* @cambiahealth/gaea


### PR DESCRIPTION
**What I did**:
remove PIE as codeowner
**How I did it**:
edit codeowners
**Why**:
because we are migrating this repo to gaea